### PR TITLE
Add SECURITY.md from org template

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,6 @@
+Please use https://g.co/vulnz to report security vulnerabilities.
+
+We use https://g.co/vulnz for our intake and triage. For valid issues we will do coordination and disclosure here on
+GitHub (including using a GitHub Security Advisory when necessary).
+
+The Google Security Team will process your report within a day, and respond within a week (although it will depend on the severity of your report).


### PR DESCRIPTION
By adding here it should propagate to all repos that don't provide their own security file.